### PR TITLE
Fixing bug where 1100 events weren't saved to CSV

### DIFF
--- a/events/lib/events/operations.ex
+++ b/events/lib/events/operations.ex
@@ -1,5 +1,6 @@
 defmodule Events.Operation do
 
+
   @event_open_code 1100
   @event_session_code 1000
   @max_value 9000
@@ -29,10 +30,10 @@ defmodule Events.Operation do
   def upsert(_code, _parent_id, _date, _value, _with_session, acc), do: acc
 
   def csv_string(doc, date) do
-    if doc[:device_id] != nil and doc[:value] <= @max_value do
-      csv_valid_string(doc, date)
-    else
+    if doc[:device_id] == nil or (doc[:value] > @max_value and doc[:code] == @event_session_code) do
       ""
+    else
+      csv_valid_string(doc, date)
     end
   end
 

--- a/events/test/operation_test.exs
+++ b/events/test/operation_test.exs
@@ -136,4 +136,15 @@ defmodule OperationTest do
     ]
     assert csv_string(document, @event_date) == "666f6f,62617a,,1000,2012-03-03 10:15:25,1000,,\n"
   end
+
+  test "app open events return correct csv string" do
+    document = [
+      _id:        {"bar"},
+      app_id:     {"foo"},
+      device_id:  {"baz"},
+      code:       1100
+    ]
+    assert csv_string(document, @event_date) == "666f6f,62617a,,1100,2012-03-03 10:15:25,,,\n"
+  end
+
 end


### PR DESCRIPTION
The max value check was applying to 1100 events too, and so they were never making it into the CSV export.
